### PR TITLE
PR: Reformat + Update 🪄 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig helps engineers define and maintain consistent
+# coding styles between different editors/IDEs and projects
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.{txt,py}]
+indent_style = space
+indent_size = 4
+
+[*.{diff,md}]
+trim_trailing_whitespace = false

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 2, June 1991
 
- Copyright (C) 1989, 1991 Free Software Foundation, Inc., <http://fsf.org/>
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
@@ -290,8 +290,8 @@ to attach them to the start of each source file to most effectively
 convey the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    {description}
-    Copyright (C) {year}  {fullname}
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -329,7 +329,7 @@ necessary.  Here is a sample; alter the names:
   Yoyodyne, Inc., hereby disclaims all copyright interest in the program
   `Gnomovision' (which makes passes at compilers) written by James Hacker.
 
-  {signature of Ty Coon}, 1 April 1989
+  <signature of Ty Coon>, 1 April 1989
   Ty Coon, President of Vice
 
 This General Public License does not permit incorporating your program into
@@ -337,4 +337,3 @@ proprietary programs.  If your program is a subroutine library, you may
 consider it more useful to permit linking proprietary applications with the
 library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.
-

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ or have a question, please
   - [Variable Naming 🐍](#variable-naming-)
   - [`README` Badges? ](#readme-badges-)
 - [Recommended Reading 📖](#recommended-reading-)
-- [Star it ⭐](#star-it-)
+- [Please Star ⭐](#please-star-)
   
 ## Why? 🤷🏻‍♀️
 
@@ -503,7 +503,7 @@ See:
 + CSS for Software Engineers:
 [speakerdeck.com/csswizardry/css-for-software-engineers](https://speakerdeck.com/csswizardry/css-for-software-engineers-for-css-developers)
 
-## Star it ⭐
+## Please Star ⭐
 
 The best way to let everyone know you have read
 and _understood_ this style guide is to

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 ![dwyl-style-guide-intro-hero-image-yellow-text](https://github.com/user-attachments/assets/1e20cfa5-94b9-4a28-8e01-8b460b4a653a "dwyl style guide retro game start screen")
 
-A style guide sets standards and improves communication.
+A style guide **sets standards** and **improves communication**.
 ~ [wikipedia.org/Style_guide](https://en.wikipedia.org/wiki/Style_guide)
 
 This style guide is a
 [**work-in-progress**](https://en.wikipedia.org/wiki/Work_in_process)
 we **need _your_ help** to _maintain_ and extend it. 🙏 <br />
 If you spot something that can be improved
-or just have a question, please
+or have a question, please
 [open an issue](https://github.com/dwyl/style-guide/issues). 💬
 
 [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat-square)](https://github.com/dwyl/style-guide/issues)
@@ -31,13 +31,16 @@ or just have a question, please
   - [Naming Repos 🌹](#naming-repos-)
   - [Naming Files 🗄️](#naming-files-️)
 - [Markdown ⬇️](#markdown-️)
-  - [Semantic Line Breaks](#semantic-line-breaks)
+  - [Semantic Line Breaks ↩](#semantic-line-breaks-)
+    - [Example 💡](#example-)
+    - [_Exception_? 🔗](#exception-)
 - [CSS 🌈](#css-)
   - [Formatting 🦄](#formatting-)
   - [Naming Conventions 🍓](#naming-conventions-)
 - [Grouping Properties 👥](#grouping-properties-)
   - [JavaScript ☕](#javascript-)
   - [Variable Naming 🐍](#variable-naming-)
+  - [`README` Badges? \](https://github.com/dwyl/style-guide/issues)](#readme-badges-httpsgithubcomdwylstyle-guideissues)
 - [Recommended Reading 📖](#recommended-reading-)
 - [Star it ⭐](#star-it-)
   
@@ -79,6 +82,10 @@ If **we don't want to _exclude_ people**
 who don't have a full-size keyboard,
 we can _only_ use spaces.
 
+> 💡 **Tip**: use the
+> [`.editorconfig`](/.editorconfig)
+> file to automatically define the indentation settings in your editor. 
+
 ### _Intelligently_ Comment Code 💬
 
 We favour the _intelligent approach_ to commenting code.
@@ -86,12 +93,12 @@ We favour the _intelligent approach_ to commenting code.
 Many developers (not us) believe that
 [well-written code doesn't need comments](http://sublimecoding.com/blog/2015/01/12/dont-comment-your-code-rewrite-it).
 Whilst it's true in a tiny hello world app where there almost no code,
-it's not the case in a codebase with many thousands of lines
-that has to be 
-[groked](https://en.wikipedia.org/wiki/Grok)
-by several distinct people.
+it's not the case in a project with many thousands of lines
+that has to be
+[**_groked_**](https://en.wikipedia.org/wiki/Grok)
+by several people of varying experience/skill levels.
 Yes, in some cases
-**adding too many comments** can also make it **_unreadable_**.
+**adding _too many_ comments** can also make it **_unreadable_**.
 The key is:
 **put yourself in the shoes** of the
 [**_next_ person**](https://www.goodreads.com/quotes/248194-always-code)
@@ -125,8 +132,7 @@ else {
 ### Quotes 🧵
 
 **Use `"` _double_ quotes `"` for `Strings`**,
-except
-When constructing a string including properties
+except when constructing a string including properties
 which are themselves denoted by single quotes:
 e.g: `var str = "<a class='big' href='/mylink'>click me</a>"`;
 
@@ -157,25 +163,36 @@ of our
 We follow a simple set of rules that streamline everything:
 
 1. Your issue/pull request `title` should be **short but descriptive**
+
 2. Use **`labels`** please! see:
 [dwyl/labels](https://github.com/dwyl/labels?tab=readme-ov-file#our-list-of-labels--%EF%B8%8F)
+
 3. To request the input of a specific person on an Issue or PR,
    mention them in a comment
    and if you want to _delegate_ a task **assign it to them**.
    However, don't just assign issues/PRs without any explanation,
    that's called [Buck passing](https://en.wikipedia.org/wiki/Buck_passing)
-4. **When referring to a file**, always do so
+
+4. When referring to a file, always do so
   within the **context of a _specific_ commit**
-  (as that file could be constantly changing and your issue will quickly stop making sense)
-  + Example: [https://github.com/dwyl/style-guide/blob/<b>dea0009638b7923521a13190f17090af37a7ff22</b>/README.md](https://github.com/dwyl/style-guide/blob/dea0009638b7923521a13190f17090af37a7ff22/README.md)
-  + and **_not_** https://github.com/dwyl/style-guide/blob/master/README.md
-  + To get this URL, go to the _History_ tab on the top right of your document and choose a commit form the list that appears
+  (as that file could be constantly changing
+  and your issue will quickly stop making sense)
+  Example:
+  [https://github.com/dwyl/style-guide/blob/dea0009638b7923521a13190f17090af37a7ff22/README.md](https://github.com/dwyl/style-guide/blob/dea0009638b7923521a13190f17090af37a7ff22/README.md)
+  and **_not_** https://github.com/dwyl/style-guide/blob/master/README.md
+  To get this URL, go to the _History_ tab on the top right of your document
+  and choose a commit form the list that appears
   <img width="288" alt="history-tab-on-git-documents" src="https://cloud.githubusercontent.com/assets/4185328/9290455/55d5dc6e-438c-11e5-851d-71127213f565.png">
-1. **When referring to a specific piece of code, include the line number** that code is on
-  + You can either add this by add `#L` and the line number to the end of the URL (e.g. https://github.com/dwyl/hapi-socketio-redis-chat-example/blame/b26354e3f37b2bdd0414b9b01bfe45db7ee9504e/lib/chat.js#L6) **or**
-  + Go to a specific commit (as above), click on 'View' and then click on 'Blame' in the top right hand corner    
+
+5. When referring to a specific piece of code,
+  include the line number that code is on.
+  Either add this by add `#L` and the line number
+  to the end of the URL
+  (e.g. https://github.com/dwyl/hapi-socketio-redis-chat-example/blame/b26354e3f37b2bdd0414b9b01bfe45db7ee9504e/lib/chat.js#L6) **or**
+  Go to a specific commit (as above), click on 'View'
+  and then click on 'Blame' in the top right hand corner:
   <img width="274" alt="blame-tab-on-git-documents" src="https://cloud.githubusercontent.com/assets/4185328/9290470/e46c2578-438c-11e5-95a7-19dfbcf82b00.png">
-  + You can now click on any line and the line number will be added to the URL
+  You can now click on any line and the line number will be added to the URL
 
 ### Commits ✨
 
@@ -258,14 +275,22 @@ e.g:
 + [`aws-sdk-mock`](https://github.com/dwyl/aws-sdk-mock)
 + [`elixir-auth-github`](https://github.com/dwyl/elixir-auth-github)
 
-> **Note**: we occasionally use underscores in repo names where 
+> **Note**: we occasionally use underscores in repo names where
+> we want to match the repo name to the _module_ name e.g:
+> [`auth_plug`](https://github.com/dwyl/auth_plug) or
+> [`dart_multihash`](https://github.com/dwyl/dart_multihash)
+> However we try to minimize this and prefer hyphens.
 
-Try to use _descriptive_ names for everything else
-(especially tutorials!)
+If a single-word name is not possible, 
+use _descriptive_ names
+(especially for tutorials!)
 e.g:
 + [`javascript-todo-list-tutorial`](https://github.com/dwyl/javascript-todo-list-tutorial)
 + [`phoenix-liveview-counter-tutorial`](https://github.com/dwyl/phoenix-liveview-counter-tutorial)
-+ 
++ [`phoenix-liveview-realtime-cursor-tracking-tutorial`](https://github.com/dwyl/phoenix-liveview-realtime-cursor-tracking-tutorial)
+
+The more descriptive the title
+the easier it will be for someone to find when searching.
 
 ### Naming Files 🗄️
 
@@ -287,8 +312,75 @@ For readability, we use:
   (so they're not confused with bold or italics on first glance)
 + **Section Headings** should always be **followed by** a **blank line**.
 
-### Semantic Line Breaks
+### Semantic Line Breaks ↩
 
+When writing prose in `markdown`
+or documentation text blocks for code,
+we try to limit the line length to **80 characters** (within reason)
+to aid readability/reviewability on smaller screens e.g: Laptops, Phones, etc.
+
+We follow the
+["Semantic Linefeed"](https://rhodesmill.org/brandon/2012/one-sentence-per-line)
+rule
+(or "one thought per line")
+whereby we line-break each time there is a "though joining word"
+such as "and", "or", "but", "therefore", "because", etc.
+thus our sentences are 
+
+#### Example 💡
+
+Avoid super long lines of text:
+
+```md
+MR. JONES, of the Manor Farm, had locked the hen-houses for the
+night, but was too drunk to remember to shut the popholes. With the
+ring of light from his lantern dancing from side to side, he lurched
+across the yard, kicked off his boots at the back door, drew himself a
+last glass of beer from the barrel in the scullery, and made his way up to
+bed, where Mrs. Jones was already snoring.
+```
+
+This super long line of text is un-reviewable/maintainable.
+
+Break it out by semantic sections:
+
+```md
+MR. JONES, of the Manor Farm,
+had locked the hen-houses for the night,
+but was too drunk to remember to shut the popholes.
+With the ring of light from his lantern dancing from side to side,
+he lurched across the yard,
+kicked off his boots at the back door,
+drew himself a last glass of beer from the barrel in the scullery,
+and made his way up to bed,
+where Mrs. Jones was already snoring.
+```
+
+_Where_ you place the linefeeds is not as important as _having_ them.
+i.e: just break up the long lines into smaller chunks that each have a though.
+And try to keep them less than **80 chars** where possible/practical.
+
+#### _Exception_? 🔗
+
+The _obvious_ exception to this is when there is a `URL`
+that is longer than **80 chars**.
+In those instances we will place the URL on its' own line
+which again, makes it easier to read/maintain/update.
+e.g:
+
+```md
+We follow the ["Semantic Linefeed"](https://rhodesmill.org/brandon/2012/one-sentence-per-line) rule in our markdown documents.
+```
+
+Becomes:
+
+```md
+We follow the
+["Semantic Linefeed"](https://rhodesmill.org/brandon/2012/one-sentence-per-line)
+rule in our markdown documents.
+```
+
+Use your best judgement. keep it easy for the _humans_ to read! 👩🏻‍💻
 
 ## CSS 🌈
 
@@ -330,7 +422,6 @@ When we need to apply styles to an element, use:
 + For further organisation, favour alphabetical ordering
   (grouping by type _always_ takes precedence)
 
-
 ### JavaScript ☕
 
 + **Use semicolons** please!
@@ -351,6 +442,11 @@ const example_object = {
   _not_ 
   [`camelCase`](https://en.wikipedia.org/wiki/CamelCase) <br />
   e.g: `let auth_token = "e2jxyz.etc.etc`
+
+### `README` Badges? ![repo-bades](https://img.shields.io/badge/badges-please-brightgreen.svg?style=flat-square)](https://github.com/dwyl/style-guide/issues)
+
+See:
+[dwyl/repo-badges](https://github.com/dwyl/repo-badges)
 
 ## Recommended Reading 📖
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ or have a question, please
   - [Naming Files 🗄️](#naming-files-️)
 - [Markdown ⬇️](#markdown-️)
   - [Use Descriptive Link Text 🔗](#use-descriptive-link-text-)
-    - [Avoid One-Word Non-Semantic Link Text](#avoid-one-word-non-semantic-link-text)
+    - [Avoid One-Word Non-Semantic Link Text 👎](#avoid-one-word-non-semantic-link-text-)
   - [Semantic Line Breaks ↩](#semantic-line-breaks-)
     - [Example 💡](#example-)
     - [_Exception_? 💭](#exception-)
@@ -42,7 +42,7 @@ or have a question, please
 - [Grouping Properties 👥](#grouping-properties-)
   - [JavaScript ☕](#javascript-)
   - [Variable Naming 🐍](#variable-naming-)
-  - [`README` Badges? \](https://github.com/dwyl/style-guide/issues)](#readme-badges-httpsgithubcomdwylstyle-guideissues)
+  - [`README` Badges? ](#readme-badges-)
 - [Recommended Reading 📖](#recommended-reading-)
 - [Star it ⭐](#star-it-)
   
@@ -283,7 +283,7 @@ e.g:
 > [`dart_multihash`](https://github.com/dwyl/dart_multihash)
 > However we try to minimize this and prefer hyphens.
 
-If a single-word name is not possible, 
+If a single-word name is not possible,
 use _descriptive_ names
 (especially for tutorials!)
 e.g:
@@ -335,7 +335,7 @@ Read our "start here" doc to learn how to do what you love:
 This is infinitely better than non-semantic link text (inaccessible!)
 which should be avoided at all costs!
 
-#### Avoid One-Word Non-Semantic Link Text
+#### Avoid One-Word Non-Semantic Link Text 👎
 
 Avoid including non-semantic link text e.g:
 
@@ -365,9 +365,9 @@ We follow the
 ["Semantic Linefeed"](https://rhodesmill.org/brandon/2012/one-sentence-per-line)
 rule
 (or "one thought per line")
-whereby we line-break each time there is a "though joining word"
+whereby we insert a break each time there is a "though joining word"
 such as "and", "or", "but", "therefore", "because", etc.
-thus our sentences are 
+thus our sentences are short and broken out by meaning.
 
 #### Example 💡
 
@@ -377,7 +377,7 @@ Avoid super long lines of text:
 MR. JONES, of the Manor Farm, had locked the hen-houses for the night, but was too drunk to remember to shut the popholes. With the ring of light from his lantern dancing from side to side, he lurched across the yard, kicked off his boots at the back door, drew himself a last glass of beer from the barrel in the scullery, and made his way up to bed, where Mrs. Jones was already snoring.
 ```
 
-This super long line of text is un-reviewable/maintainable.
+This super long line of text is un-reviewable/maintainable. 😢
 
 Break it out by semantic sections:
 
@@ -419,7 +419,8 @@ We follow the
 rule in our markdown documents.
 ```
 
-Use your best judgement. keep it easy for the _humans_ to read! 👩🏻‍💻
+Use your best judgement.
+Keep it easy for the _humans_ to read! 👩🏻‍💻
 
 ## CSS 🌈
 
@@ -482,8 +483,9 @@ const example_object = {
   [`camelCase`](https://en.wikipedia.org/wiki/CamelCase) <br />
   e.g: `let auth_token = "e2jxyz.etc.etc`
 
-### `README` Badges? ![repo-bades](https://img.shields.io/badge/badges-please-brightgreen.svg?style=flat-square)](https://github.com/dwyl/style-guide/issues)
+### `README` Badges? [![repo-bades](https://img.shields.io/badge/badges-please-brightgreen.svg?style=flat-square)](https://github.com/dwyl/style-guide/issues)
 
+We use badges _extensively_ in our projects.
 See:
 [dwyl/repo-badges](https://github.com/dwyl/repo-badges)
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ or have a question, please
   - [Semantic Line Breaks ↩](#semantic-line-breaks-)
     - [Example 💡](#example-)
     - [_Exception_? 💭](#exception-)
-- [CSS 🌈](#css-)
+- [CSS 👩‍🎨](#css-)
   - [Formatting 🦄](#formatting-)
   - [Naming Conventions 🍓](#naming-conventions-)
   - [Grouping Properties 👥](#grouping-properties-)
@@ -377,7 +377,7 @@ thus our sentences are short and broken out by meaning.
 Avoid super long lines of text:
 
 ```md
-MR. JONES, of the Manor Farm, had locked the hen-houses for the night, but was too drunk to remember to shut the popholes. With the ring of light from his lantern dancing from side to side, he lurched across the yard, kicked off his boots at the back door, drew himself a last glass of beer from the barrel in the scullery, and made his way up to bed, where Mrs. Jones was already snoring.
+MR. Jones, of the Manor Farm, had locked the hen-houses for the night, but was too drunk to remember to shut the popholes. With the ring of light from his lantern dancing from side to side, he lurched across the yard, kicked off his boots at the back door, drew himself a last glass of beer from the barrel in the scullery, and made his way up to bed, where Mrs. Jones was already snoring.
 ```
 
 This super long line of text is un-reviewable/maintainable. 😢
@@ -385,7 +385,7 @@ This super long line of text is un-reviewable/maintainable. 😢
 Break it out by semantic sections:
 
 ```md
-MR. JONES, of the Manor Farm,
+MR. Jones, of the Manor Farm,
 had locked the hen-houses for the night,
 but was too drunk to remember to shut the popholes.
 With the ring of light from his lantern dancing from side to side,
@@ -412,7 +412,7 @@ e.g:
 We follow the ["Semantic Linefeed"](https://rhodesmill.org/brandon/2012/one-sentence-per-line) rule in our markdown documents.
 ```
 
-> **Note**: That sentence requires horizontal scrolling, a time-suck. 😕
+> **Note**: That sentence requires horizontal scrolling, a time-suck. ⏳😕
 
 Becomes:
 
@@ -425,7 +425,7 @@ rule in our markdown documents.
 Use your best judgement.
 Keep it easy for the _humans_ to read! 👩🏻‍💻
 
-## CSS 🌈
+## CSS 👩‍🎨
 
 + Learn and _Use_ `Tailwind CSS`
   [dwyl/learn-tailwind](https://github.com/dwyl/learn-tailwind)

--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ or have a question, please
   - [Naming Repos 🌹](#naming-repos-)
   - [Naming Files 🗄️](#naming-files-️)
 - [Markdown ⬇️](#markdown-️)
+  - [Use Descriptive Link Text 🔗](#use-descriptive-link-text-)
+    - [Avoid One-Word Non-Semantic Link Text](#avoid-one-word-non-semantic-link-text)
   - [Semantic Line Breaks ↩](#semantic-line-breaks-)
     - [Example 💡](#example-)
-    - [_Exception_? 🔗](#exception-)
+    - [_Exception_? 💭](#exception-)
 - [CSS 🌈](#css-)
   - [Formatting 🦄](#formatting-)
   - [Naming Conventions 🍓](#naming-conventions-)
@@ -312,6 +314,46 @@ For readability, we use:
   (so they're not confused with bold or italics on first glance)
 + **Section Headings** should always be **followed by** a **blank line**.
 
+### Use Descriptive Link Text 🔗
+
+We prefer to _either_ use **_super_ descriptive link text**
+e.g:
+
+```md
+Learn how to do what you love by reading the 
+[start here repo](https://github.com/dwyl/start-here).
+```
+
+Or simply use the **`URL`** as the **link text**
+e.g:
+
+```md
+Read our "start here" doc to learn how to do what you love:
+[dwyl/start-here](https://github.com/dwyl/start-here)
+```
+
+This is infinitely better than non-semantic link text (inaccessible!)
+which should be avoided at all costs!
+
+#### Avoid One-Word Non-Semantic Link Text
+
+Avoid including non-semantic link text e.g:
+
+```md
+You can find more info [here](https://en.wikipedia.org/wiki/Computer_security) on Cyber Security.
+```
+
+or
+
+```md
+[Click here](https://en.wikipedia.org/wiki/Pok%C3%A9mon_the_Series:_XYZ) for more details on **XYZ**.
+```
+
+Both of these examples are _horrible_ for accessibility and should be avoided.
+
+Read more:
+[mtu.edu/accessibility/training/web/link-text/](https://www.mtu.edu/accessibility/training/web/link-text/)
+
 ### Semantic Line Breaks ↩
 
 When writing prose in `markdown`
@@ -332,12 +374,7 @@ thus our sentences are
 Avoid super long lines of text:
 
 ```md
-MR. JONES, of the Manor Farm, had locked the hen-houses for the
-night, but was too drunk to remember to shut the popholes. With the
-ring of light from his lantern dancing from side to side, he lurched
-across the yard, kicked off his boots at the back door, drew himself a
-last glass of beer from the barrel in the scullery, and made his way up to
-bed, where Mrs. Jones was already snoring.
+MR. JONES, of the Manor Farm, had locked the hen-houses for the night, but was too drunk to remember to shut the popholes. With the ring of light from his lantern dancing from side to side, he lurched across the yard, kicked off his boots at the back door, drew himself a last glass of beer from the barrel in the scullery, and made his way up to bed, where Mrs. Jones was already snoring.
 ```
 
 This super long line of text is un-reviewable/maintainable.
@@ -356,11 +393,11 @@ and made his way up to bed,
 where Mrs. Jones was already snoring.
 ```
 
-_Where_ you place the linefeeds is not as important as _having_ them.
-i.e: just break up the long lines into smaller chunks that each have a though.
-And try to keep them less than **80 chars** where possible/practical.
+_Where_ you place the line breaks is not as important as _having_ them.
+i.e: just break up the long lines into smaller chunks that each have a though,
+and try to keep them less than **80 chars** where possible/practical.
 
-#### _Exception_? 🔗
+#### _Exception_? 💭
 
 The _obvious_ exception to this is when there is a `URL`
 that is longer than **80 chars**.
@@ -371,6 +408,8 @@ e.g:
 ```md
 We follow the ["Semantic Linefeed"](https://rhodesmill.org/brandon/2012/one-sentence-per-line) rule in our markdown documents.
 ```
+
+> **Note**: That sentence requires horizontal scrolling, a time-suck. 😕
 
 Becomes:
 
@@ -452,6 +491,8 @@ See:
 
 + 29 Well-Designed Online Style Guides
 [webdesignledger.com/29-online-style-guides](https://webdesignledger.com/29-online-style-guides/)
++ Tips on writing Descriptive Link Text:
+[mtu.edu/accessibility/training/web/link-text](https://www.mtu.edu/accessibility/training/web/link-text/)
 + Useful tips for better commit messages:
 [thoughtbot.com/5-useful-tips-for-a-better-commit-message](https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message)
 + CSS for Software Engineers:

--- a/README.md
+++ b/README.md
@@ -14,30 +14,29 @@ we **need _your_ help** to _maintain_ and extend it. 🙏
 
 </div>
 
-- [Why?](#why)
-- [General](#general)
-  - [Indentation](#indentation)
-  - [_Intelligently_ Comment Code](#intelligently-comment-code)
-  - [Quotes](#quotes)
-- [Git](#git)
-  - [Issues](#issues)
-  - [Commits](#commits)
-  - [Pull Requests](#pull-requests)
-    - [_Reviewing_ PRs](#reviewing-prs)
-  - [Naming Repos](#naming-repos)
-- [Markdown](#markdown)
-- [CSS](#css)
-  - [General points](#general-points)
-  - [Indentation](#indentation-1)
-  - [Naming Conventions](#naming-conventions)
-- [Grouping Properties](#grouping-properties)
-  - [JavaScript](#javascript)
-  - [Variable naming](#variable-naming)
-- [Recommended Reading](#recommended-reading)
+- [Why? 🤷🏻‍♀️](#why-️)
+- [General 👋](#general-)
+  - [Indentation 🪐](#indentation-)
+  - [_Intelligently_ Comment Code 💬](#intelligently-comment-code-)
+  - [Quotes 🧵](#quotes-)
+- [Git 👩‍💻](#git-)
+  - [Issues 📝](#issues-)
+  - [Commits ✨](#commits-)
+  - [Pull Requests 🚀](#pull-requests-)
+    - [_Reviewing_ PRs 👀](#reviewing-prs-)
+  - [Naming Repos 🌹](#naming-repos-)
+- [Markdown ⬇️](#markdown-️)
+- [CSS 🌈](#css-)
+  - [Indentation ✌️](#indentation-️)
+  - [Naming Conventions 🍓](#naming-conventions-)
+- [Grouping Properties 👥](#grouping-properties-)
+  - [JavaScript ☕](#javascript-)
+  - [Variable Naming 🐍](#variable-naming-)
+- [Recommended Reading 📖](#recommended-reading-)
   
-## Why?
+## Why? 🤷🏻‍♀️
 
-**_Consistency_**.
+**_Consistency_**. 😍
 
 Creative people often like to do things their own way.
 That can often lead to projects that look wildly different from each other.
@@ -46,9 +45,9 @@ We need **_everything_ consistent** so new people
 _don't have to work through personal formatting quirks_
 of previous engineers and can **focus on the code**. 🎯
 
-## General
+## General 👋
 
-### Indentation
+### Indentation 🪐
 
 We use
 **2 spaces for indentation**
@@ -63,7 +62,7 @@ If **we don't want to _exclude_ people**
 who don't have a full-size keyboard,
 we can _only_ use spaces.
 
-### _Intelligently_ Comment Code
+### _Intelligently_ Comment Code 💬
 
 We favour the _intelligent approach_.
 
@@ -98,7 +97,7 @@ else {
 > It's because they have _experience_ of reading lots of code
 > and want to help the _next_ person understand it the way you do _now_.
 
-### Quotes
+### Quotes 🧵
 
 **Use `"` _double_ quotes `"` for `Strings`**,
 except
@@ -106,9 +105,9 @@ When constructing a string including properties
 which are themselves denoted by single quotes:
 e.g: `var str = "<a class='big' href='/mylink'>click me</a>"`;
 
-## Git
+## Git 👩‍💻
 
-### Issues
+### Issues 📝
 
 + Your issue/pull request `title` should be **short but descriptive**
 + Use **`labels`** please! see:
@@ -127,7 +126,7 @@ e.g: `var str = "<a class='big' href='/mylink'>click me</a>"`;
   <img width="274" alt="blame-tab-on-git-documents" src="https://cloud.githubusercontent.com/assets/4185328/9290470/e46c2578-438c-11e5-95a7-19dfbcf82b00.png">
   + You can now click on any line and the line number will be added to the URL
 
-### Commits
+### Commits ✨
 
 + Use the **third person present tense** in your commit messages,
   as if you were finishing off the sentence _"This commit message..."_
@@ -151,7 +150,7 @@ e.g: `var str = "<a class='big' href='/mylink'>click me</a>"`;
 
 <img width="695" alt="emojis-in-commit-messages" src="https://cloud.githubusercontent.com/assets/4185328/9212573/14112b74-4082-11e5-822e-bc66250c5712.png">
 
-### Pull Requests
+### Pull Requests 🚀
 
 A _good_ pull request (PR) reduces the back and forth
 required between the person submitting the PR
@@ -162,7 +161,7 @@ For our guidelines on contributing pull requests to dwyl projects,
 please see:
 [dwyl/contributing](https://github.com/dwyl/contributing)
 
-#### _Reviewing_ PRs
+#### _Reviewing_ PRs 👀
 
 + [Inline comments on github](https://help.github.com/articles/commenting-on-the-diff-of-a-pull-request/)
   are very useful when reviewing pull requests,
@@ -171,14 +170,14 @@ please see:
 <img width="940" alt="add-comment-inline-in-pr-comment-box"
   src="https://cloud.githubusercontent.com/assets/4185328/9238544/0d293b20-414b-11e5-8604-15ba4f229525.png">
 
-### Naming Repos
+### Naming Repos 🌹
 
 + We favour one-word names for **node modules**
   (make sure the name is available)
   and _descriptive_ names for everything else
   (especially tutorials!)
 
-## Markdown
+## Markdown ⬇️
 
 We recommend being competent in **`Markdown`**
 as we use it every day.
@@ -189,13 +188,14 @@ For readability, we use:
 + `**` **double asterisks** `**` for **bold**
 + `+` plus signs for bullet points
   (so they're not confused with bold or italics on first glance)
++ **Section Headings** should always be **followed by** a **blank line**.
 
-## CSS
 
-### General points
+## CSS 🌈
 
-+ Learn and Use `Tailwind CSS`
++ Learn and _Use_ `Tailwind CSS`
   [dwyl/learn-tailwind](https://github.com/dwyl/learn-tailwind)
+  great _interface_ is the key to a great _experience_.
 + If you use a _separate_ CSS file,
   use _classes_, **not IDs** as your hooks
 + Explicitly select **what you want** rather than fumbling around
@@ -206,7 +206,7 @@ For readability, we use:
 + Pick class names that are as re-usable as possible
   (e.g. pick `primary-nav` over `site-nav`)
 
-### Indentation
+### Indentation ✌️
 
 CSS indentation should mirror the `HTML` markup structure,
 e.g: 
@@ -216,14 +216,14 @@ e.g:
   .article-quote {}
 ```
 
-### Naming Conventions
+### Naming Conventions 🍓
 
 When we need to apply styles to an element, use:
 
 + Semantic class names (e.g. not `green-btn` but `primary-action-btn`)
 + BEM-like _modifier_ syntax (using `--`), e.g. modifying `.site-logo` to `.site-logo--xmas`
 
-## Grouping Properties
+## Grouping Properties 👥
 
 + Group properties **by type**
   e.g: `font` and `text-align` properties would sit together,
@@ -232,7 +232,7 @@ When we need to apply styles to an element, use:
   (grouping by type _always_ takes precedence)
 
 
-### JavaScript
+### JavaScript ☕
 
 + **Use semicolons** please!
 + **No trailing commas** on object declarations:
@@ -244,7 +244,7 @@ const example_object = {
 };
 ```
 
-### Variable naming
+### Variable Naming 🐍
 
 + If you can, use a descriptive **one word** variable name
 + If one word isn't enough, **use underscores to separate words**
@@ -252,7 +252,9 @@ const example_object = {
   and not [`camelCase`](https://en.wikipedia.org/wiki/CamelCase),
   e.g: `let auth_token = "e2jxyz.etc.etc`
 
-## Recommended Reading
+## Recommended Reading 📖
 
 + 29 Well-Designed Online Style Guides
 [webdesignledger.com/29-online-style-guides](https://webdesignledger.com/29-online-style-guides/)
++ Useful tips for better commit messages:
+[thoughtbot.com/5-useful-tips-for-a-better-commit-message](https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message)

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ or have a question, please
 - [CSS 🌈](#css-)
   - [Formatting 🦄](#formatting-)
   - [Naming Conventions 🍓](#naming-conventions-)
-- [Grouping Properties 👥](#grouping-properties-)
-  - [JavaScript ☕](#javascript-)
+  - [Grouping Properties 👥](#grouping-properties-)
+- [JavaScript ☕](#javascript-)
   - [Variable Naming 🐍](#variable-naming-)
   - [`README` Badges? ](#readme-badges-)
 - [Recommended Reading 📖](#recommended-reading-)
@@ -129,14 +129,15 @@ else {
 > **Note**: try not to be offended if someone reviewing your PR/code
 > asks you to **please add comments**.
 > It's because they have _experience_ of reading lots of code
-> and want to help the _next_ person understand it the way you do _now_.
+> and want to help the _next_ person
+> understand it the way you do _now_. 😊
 
 ### Quotes 🧵
 
 **Use `"` _double_ quotes `"` for `Strings`**,
 except when constructing a string including properties
 which are themselves denoted by single quotes:
-e.g: `var str = "<a class='big' href='/mylink'>click me</a>"`;
+e.g: `var str = "<a class='big' href='/register'>Register To Comment</a>";`
 
 Most programming languages we use,
 e.g:
@@ -145,7 +146,8 @@ e.g:
 [`Dart`](https://stackoverflow.com/a/54014914/1148249)
 allow single and double quotes to be used _interchangeably_.
 But `Elixir` and `JSON` do not.
-`String` in `Elixir` _must_ use double-quotes,
+[`String`](https://hexdocs.pm/elixir/1.17/String.html)
+in `Elixir` _must_ use **double-quotes**,
 and _valid_ `JSON` keys/values _must_ be surrounded by double-quotes.
 This is why we use double-quotes for `Strings`;
 it makes everyone's life easier/faster when switching between code bases.
@@ -156,6 +158,7 @@ Again, this isn't a debate. 😊
 
 If you are new to `Git` and/or `GitHub`
 we recommend reading our **`Git` Guide**:
+[dwyl/git-guide](https://github.com/dwyl/git-guide)
 
 ### Issues 📝
 
@@ -454,7 +457,7 @@ When we need to apply styles to an element, use:
 + Semantic class names (e.g. not `green-btn` but `primary-action-btn`)
 + BEM-like _modifier_ syntax (using `--`), e.g. modifying `.site-logo` to `.site-logo--xmas`
 
-## Grouping Properties 👥
+### Grouping Properties 👥
 
 + Group properties **by type**
   e.g: `font` and `text-align` properties would sit together,
@@ -462,7 +465,7 @@ When we need to apply styles to an element, use:
 + For further organisation, favour alphabetical ordering
   (grouping by type _always_ takes precedence)
 
-### JavaScript ☕
+## JavaScript ☕
 
 + **Use semicolons** please!
 + **No trailing commas** on object declarations:
@@ -481,7 +484,7 @@ const example_object = {
   [`snake_case`](https://en.wikipedia.org/wiki/Snake_case))
   _not_ 
   [`camelCase`](https://en.wikipedia.org/wiki/CamelCase) <br />
-  e.g: `let auth_token = "e2jxyz.etc.etc`
+  e.g: `let auth_token = "e2jxyz.etc.etc"`
 
 ### `README` Badges? [![repo-bades](https://img.shields.io/badge/badges-please-brightgreen.svg?style=flat-square)](https://github.com/dwyl/style-guide/issues)
 
@@ -504,6 +507,6 @@ See:
 
 The best way to let everyone know you have read
 and _understood_ this style guide is to
-star the repo on `GitHub`. 🌟
+**star** the `GitHub` repo. 🌟
 
 Thank you! ❤️

--- a/README.md
+++ b/README.md
@@ -1,87 +1,124 @@
-# dwyl Style Guide 
+<div align="center">
 
->A style guide is a set of standards [which] establish and enforce style to improve communication.
+![dwyl-style-guide-intro-hero-image-yellow-text](https://github.com/user-attachments/assets/1e20cfa5-94b9-4a28-8e01-8b460b4a653a)
 
-<small>_https://en.wikipedia.org/wiki/Style_guide_</small>
+A style guide sets standards and improves communication.
+~ [wikipedia.org/Style_guide](https://en.wikipedia.org/wiki/Style_guide)
 
-**_This style guide is a work in progress and is being put together over the course of [#dwylsummer](https://github.com/dwyl/summer-2015)_** and the rest of our work.
+This style guide is a
+[**work-in-progress**](https://en.wikipedia.org/wiki/Work_in_process)
+we **need _your_ help** to _maintain_ and extend it. 🙏
 
-[![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/dwyl/style-guide/issues) Please open an issue if you have an questions or comments at all!
+[![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat-square)](https://github.com/dwyl/style-guide/issues)
+[![HitCount](https://hits.dwyl.com/dwyl/style-guide.svg?style=flat-square)](https://hits.dwyl.com/dwyl/style-guide)
 
-For now, the **visual** and **coding styles** [will live in the _same repo_](https://github.com/dwyl/summer-2015/issues/22). If the size of this readme gets out of hand or if we have a lot of requests to separate them, we'll do so.
+</div>
 
-## Contents Guide
-+ [Why?](#why)
-+ [General guidelines](#general)
-  + [2 Space indentation](#indentation)
-  + [Intelligently commenting your code](#intelligently-commenting-your-code)
-  + [Single quotes](#quotes)
-+ [Git](#git) 
-  + [Issues](#issues)
-  + [Commits](#commits)
-  + [Pull requests](#pull-requests)
-  + [Naming repositories](#naming-repos)
-+ [Markdown](#markdown)
-+ [CSS](#css) (WiP)
-  + [General points](#general-points)
-  + [Indentation](#indentation)
-  + [Naming conventions](#naming-conventions)
-  + [Grouping properties](#grouping-properties)
-+ [JavaScript](#javascript) (WiP)
+- [Why?](#why)
+- [General](#general)
+  - [Indentation](#indentation)
+  - [_Intelligently_ Comment Code](#intelligently-comment-code)
+  - [Quotes](#quotes)
+- [Git](#git)
+  - [Issues](#issues)
+  - [Commits](#commits)
+  - [Pull Requests](#pull-requests)
+    - [_Reviewing_ PRs](#reviewing-prs)
+  - [Naming Repos](#naming-repos)
+- [Markdown](#markdown)
+- [CSS](#css)
+  - [General points](#general-points)
+  - [Indentation](#indentation-1)
+  - [Naming Conventions](#naming-conventions)
+- [Grouping Properties](#grouping-properties)
+  - [JavaScript](#javascript)
+  - [Variable naming](#variable-naming)
+- [Recommended Reading](#recommended-reading)
   
-
 ## Why?
-**Consistency**.    
 
-Every developer likes to do things their own way.    
-Even though we have our own idea of what maintainable code looks like, _the important thing_ isn't how many spaces we indent our code with but that **everything is consistent** so new people _don't have to work through personal formatting quirks_ of previous developers and can **focus on the code**.
-<br />
-<br />
+**_Consistency_**.
+
+Creative people often like to do things their own way.
+That can often lead to projects that look wildly different from each other.
+This slows down new people and wastes time.
+We need **_everything_ consistent** so new people
+_don't have to work through personal formatting quirks_
+of previous engineers and can **focus on the code**. 🎯
 
 ## General
 
 ### Indentation
-**2 space indentation** (see our [developer setup guide](https://github.com/dwyl/setup) for tips on setting this kind of thing up in your text editor).
 
-### Intelligently commenting your code
+We use
+**2 spaces for indentation**
+see:
+[developer setup guide](https://github.com/dwyl/dev-setup?tab=readme-ov-file#basic-text-editor-setup)
+for tips on setting this kind of thing up in your text editor.
+
+This isn't up for debate.
+There is no **`tab`** key on Smartphones;
+which is the most ubiquitous input device.
+If **we don't want to _exclude_ people**
+who don't have a full-size keyboard,
+we can _only_ use spaces.
+
+### _Intelligently_ Comment Code
+
 We favour the _intelligent approach_.
 
-Many developers (not us) believe that [well-written code doesn't need comments](http://sublimecoding.com/blog/2015/01/12/dont-comment-your-code-rewrite-it).
-Whilst it's true that **adding too many comments to your code makes it unreadable**. The key is to **put yourself in the shoes of the next person who has to work with your code**. 
+Many developers (not us) believe that
+[well-written code doesn't need comments](http://sublimecoding.com/blog/2015/01/12/dont-comment-your-code-rewrite-it).
+Whilst it's true that
+**adding too many comments to your code makes it _unreadable_**.
+The key is: **put yourself in the shoes of the _next_ person who has to work with the code**.
 
-If you feel **your code is as simple as it can be** but what it doesn't isn't immediately obvious, then add a comment.    
-Good examples of this are when something in your code in one location necessarily has an impact elsewhere.
+If you feel **your code is as simple as it can be**
+but what it does isn't immediately obvious, then **add a comment**.
+Good examples of this are when something in your code
+in one location necessarily has an impact elsewhere.
 
 ```javascript
-//JavaScript example
+// JavaScript example
 else {
-  mod = moduleName.replace('.js', '.\.js'); //escape .js for regex
+  mod = moduleName.replace('.js', '.\.js'); // escape .js for regex
 }
 ```
 
 ```css
-/*CSS example*/
+/* CSS example */
 .article {
-  position: relative; /*contains `.quote` which is positioned absolutely*/
+  position: relative; /* contains `.quote` which is positioned absolutely */
   ...
 }
 ```
-### Quotes
-**Use `'` single quotes `'` everywhere**, except: 
-+ When constructing a string including properties which are themselves denoted by single quotes:   
-e.g: `var str = "<a class='big' href='/mylink'>click me</a>"`;
-+ When *manually* creating a **JSON** object/file (as these [are not valid JSON](https://github.com/dwyl/style-guide/issues/5#issuecomment-130252764))
 
-<br />
+> **Note**: try not to be offended if someone reviewing your PR/code
+> asks you to **please add comments**.
+> It's because they have _experience_ of reading lots of code
+> and want to help the _next_ person understand it the way you do _now_.
+
+### Quotes
+
+**Use `"` _double_ quotes `"` for `Strings`**,
+except
+When constructing a string including properties
+which are themselves denoted by single quotes:
+e.g: `var str = "<a class='big' href='/mylink'>click me</a>"`;
 
 ## Git
 
 ### Issues
-+ Your issue title should be **short but descriptive**
-+ Use **labels** please!
+
++ Your issue/pull request `title` should be **short but descriptive**
++ Use **`labels`** please! see:
+[dwyl/labels](https://github.com/dwyl/labels?tab=readme-ov-file#our-list-of-labels--%EF%B8%8F)
 + If you want someone specific to look at your issue, **assign it to them**
-+ **When referring to a file**, always do so within the **context of a specific commit** (as that file could be constantly changing and your issue will quickly stop making sense)
-  + Example: [https://github.com/dwyl/style-guide/blob/<b>dea0009638b7923521a13190f17090af37a7ff22</b>/README.md](https://github.com/dwyl/style-guide/blob/dea0009638b7923521a13190f17090af37a7ff22/README.md) and **_not_** https://github.com/dwyl/style-guide/blob/master/README.md
++ **When referring to a file**, always do so
+  within the **context of a _specific_ commit**
+  (as that file could be constantly changing and your issue will quickly stop making sense)
+  + Example: [https://github.com/dwyl/style-guide/blob/<b>dea0009638b7923521a13190f17090af37a7ff22</b>/README.md](https://github.com/dwyl/style-guide/blob/dea0009638b7923521a13190f17090af37a7ff22/README.md)
+  + and **_not_** https://github.com/dwyl/style-guide/blob/master/README.md
   + To get this URL, go to the _History_ tab on the top right of your document and choose a commit form the list that appears    
   <img width="288" alt="history-tab-on-git-documents" src="https://cloud.githubusercontent.com/assets/4185328/9290455/55d5dc6e-438c-11e5-851d-71127213f565.png">
 + **When referring to a specific piece of code, include the line number** that code is on
@@ -91,72 +128,109 @@ e.g: `var str = "<a class='big' href='/mylink'>click me</a>"`;
   + You can now click on any line and the line number will be added to the URL
 
 ### Commits
-+ Use the **third person present tense** in your commit messages, as if you were finishing off the sentence _"This commit message..."_
-  + For example _"adds riot.js to index"_ or _"fixes #12 disappearing content bug"_
-+ **Include an issue number in _every commit message_**
-  + The commit message will then appear within that issue and ensure traceability of every contribution    
+
++ Use the **third person present tense** in your commit messages,
+  as if you were finishing off the sentence _"This commit message..."_
+  e.g: _"adds atm.js to index.html #420"_ or _"fixes disappearing content bug #12"_
++ **Include an issue number in _every_ commit message**
+  + The commit message will then appear within that issue and ensure traceability of every contribution.
   
 <img width="704" alt="commit-message-referenced-from-issue" src="https://cloud.githubusercontent.com/assets/4185328/9212670/dda6840c-4082-11e5-8e58-c4077f5ab089.png">
+
 + Keep your commits **'common sensibly small'**
-  + A good rule of thumb is that _if you have to use the word 'and' in your commit message, you're probably doing too much in a single commit_ unless the things you're committing are intrinsically tied together.
-+ **If you're pairing**, consider giving your pair some credit in your commit messages by including their initials:
+  + A good rule of thumb is that _if you have to use the word "and"
+  in your commit message, you're probably doing too much in a single commit_
+  unless the things you're committing are intrinsically tied together.
++ **If you're pairing**, consider giving your pair some credit
+  in your commit messages by including their initials:
 
 <img width="723" alt="paired-commit-message" src="https://cloud.githubusercontent.com/assets/4185328/9212496/3adc19c2-4081-11e5-956c-8655c1f37946.png">
-+ Did you know you can [use emojis in your commit messages](https://github.com/dwyl/start-here/issues/49)? It's totally a thing.
+
++ Did you know you can
+  [use emojis in your commit messages](https://github.com/dwyl/start-here/issues/49)?
+
 <img width="695" alt="emojis-in-commit-messages" src="https://cloud.githubusercontent.com/assets/4185328/9212573/14112b74-4082-11e5-822e-bc66250c5712.png">
 
-
 ### Pull Requests
-Good pull requests (PR) reduce the back and forth required between the person submitting the PR and the assigned reviewer, saving everyone time.
 
-For our guidelines on contributing pull requests to dwyl projects, please see: https://github.com/dwyl/contributing
+A _good_ pull request (PR) reduces the back and forth
+required between the person submitting the PR
+and the assigned reviewer,
+[saving _everyone_ time](https://github.com/dwyl/start-here/blob/63468a6bc020f88c762465823da7419478f29687/manifesto.md#your-time-should-never-be-wasted).
 
-#### Reviewing pull requests
-+ [Inline comments on github](https://help.github.com/articles/commenting-on-the-diff-of-a-pull-request/) are very useful when reviewing pull requests, both for traceability and speed of review.
+For our guidelines on contributing pull requests to dwyl projects,
+please see:
+[dwyl/contributing](https://github.com/dwyl/contributing)
 
-<img width="940" alt="add-comment-inline-in-pr-comment-box" src="https://cloud.githubusercontent.com/assets/4185328/9238544/0d293b20-414b-11e5-8604-15ba4f229525.png">
+#### _Reviewing_ PRs
 
-### Naming repos
-+ We favour one-word names for **node modules** (make sure the name is available [on npm](http://www.npmjs.com)) and descriptive names for everything else (especially tutorials!)
++ [Inline comments on github](https://help.github.com/articles/commenting-on-the-diff-of-a-pull-request/)
+  are very useful when reviewing pull requests,
+  both for traceability and speed of review.
 
-<br />
+<img width="940" alt="add-comment-inline-in-pr-comment-box"
+  src="https://cloud.githubusercontent.com/assets/4185328/9238544/0d293b20-414b-11e5-8604-15ba4f229525.png">
+
+### Naming Repos
+
++ We favour one-word names for **node modules**
+  (make sure the name is available)
+  and _descriptive_ names for everything else
+  (especially tutorials!)
 
 ## Markdown
-[This is a good reference for markdown syntax](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet).    
-For readability, we use:
- + `_` _underscores_ `_` for _italics_ 
- + `**` **double asterisks** `**` for **bold**
- + `+` plus signs for bullet points (so they're not confused with bold or italics on first glance)
 
-<br />
+We recommend being competent in **`Markdown`**
+as we use it every day.
+[markdown cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet).
+For readability, we use:
+
++ `_` _underscores_ `_` for _italics_
++ `**` **double asterisks** `**` for **bold**
++ `+` plus signs for bullet points
+  (so they're not confused with bold or italics on first glance)
 
 ## CSS
+
 ### General points
-+ Use _classes_, **not IDs** as your hooks
-+ Explicitly select **what you want** rather than fumbling around the HTML structure searching for hooks - practice good [_selector intent_](http://csswizardry.com/2012/07/shoot-to-kill-css-selector-intent/)
-  + i.e. if you're styling a site's navigation, style `primary-nav` instead of `header ul`
-+ Pick class names that are as re-usable as possible (e.g. pick `primary-nav` over `site-nav`)
+
++ Learn and Use `Tailwind CSS`
+  [dwyl/learn-tailwind](https://github.com/dwyl/learn-tailwind)
++ If you use a _separate_ CSS file,
+  use _classes_, **not IDs** as your hooks
++ Explicitly select **what you want** rather than fumbling around
+  the `HTML` structure searching for hooks - practice good
+  [_selector intent_](http://csswizardry.com/2012/07/shoot-to-kill-css-selector-intent/)
+  + i.e: if you're styling a site's navigation,
+  style `primary-nav` instead of `header ul`
++ Pick class names that are as re-usable as possible
+  (e.g. pick `primary-nav` over `site-nav`)
 
 ### Indentation
-CSS indentation should mirror the HTML structure.
+
+CSS indentation should mirror the `HTML` markup structure,
+e.g: 
+
 ```css
 .article {}
   .article-quote {}
 ```
 
-### Naming conventions
-**_For now_**, we _don't_ use [BEM CSS naming conventions](https://github.com/dwyl/start-here/issues/41) as it doesn't provide the _flexibility_ we feel we need during the early stages of our work.     
-Here's what we _do_ use:
+### Naming Conventions
+
+When we need to apply styles to an element, use:
+
 + Semantic class names (e.g. not `green-btn` but `primary-action-btn`)
 + BEM-like _modifier_ syntax (using `--`), e.g. modifying `.site-logo` to `.site-logo--xmas`
 
-## Grouping properties
-* Group properties **by type**
-  * For example, `font` and `text-align` properties would sit together, as would `border`, `display`, `height` and `width` properties
-* For further organisation, favour alphabetical ordering (grouping by type _always_ takes precedence)
+## Grouping Properties
 
++ Group properties **by type**
+  e.g: `font` and `text-align` properties would sit together,
+  as would `border`, `display`, `height` and `width` properties
++ For further organisation, favour alphabetical ordering
+  (grouping by type _always_ takes precedence)
 
-<br />
 
 ### JavaScript
 
@@ -164,16 +238,21 @@ Here's what we _do_ use:
 + **No trailing commas** on object declarations:
 
 ```javascript
-var example_object = {
+const example_object = {
     name: 'dwyl',
     age: 1 //<-- Having a comma after the '1' would be a 'trailing comma' 
 };
 ```
 
 ### Variable naming
+
 + If you can, use a descriptive **one word** variable name
-+ If one word isn't enough, **use underscores to separate words** ([snake case](https://en.wikipedia.org/wiki/Snake_case)) and not [camel case](https://en.wikipedia.org/wiki/CamelCase): `var example_variable`
++ If one word isn't enough, **use underscores to separate words**
+  ([`snake_case`](https://en.wikipedia.org/wiki/Snake_case))
+  and not [`camelCase`](https://en.wikipedia.org/wiki/CamelCase),
+  e.g: `let auth_token = "e2jxyz.etc.etc`
 
-https://github.com/dwyl/summer-2015/issues/22
+## Recommended Reading
 
-
++ 29 Well-Designed Online Style Guides
+[webdesignledger.com/29-online-style-guides](https://webdesignledger.com/29-online-style-guides/)

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ or just have a question, please
   - [Commits ✨](#commits-)
   - [Pull Requests 🚀](#pull-requests-)
     - [_Reviewing_ PRs 👀](#reviewing-prs-)
-    - [Use In-line Code Suggestions in PRs! 💡](#use-in-line-code-suggestions-in-prs-)
+    - [Use In-line Code Suggestions in PRs! 📝](#use-in-line-code-suggestions-in-prs-)
   - [Naming Repos 🌹](#naming-repos-)
+  - [Naming Files 🗄️](#naming-files-️)
 - [Markdown ⬇️](#markdown-️)
   - [Semantic Line Breaks](#semantic-line-breaks)
 - [CSS 🌈](#css-)
@@ -213,28 +214,65 @@ please see:
 
 #### _Reviewing_ PRs 👀
 
-+ [Inline comments on github](https://help.github.com/articles/commenting-on-the-diff-of-a-pull-request/)
-  are very useful when reviewing pull requests,
-  both for traceability and speed of review.
+Use 
+[inline comments on github](https://help.github.com/articles/commenting-on-the-diff-of-a-pull-request/)
+when reviewing pull requests,
+both for traceability and to help the person submitting the PR improve.
 
 <img width="940" alt="add-comment-inline-in-pr-comment-box"
   src="https://cloud.githubusercontent.com/assets/4185328/9238544/0d293b20-414b-11e5-8604-15ba4f229525.png">
 
-#### Use In-line Code Suggestions in PRs! 💡
+#### Use In-line Code Suggestions in PRs! 📝
 
 When there is a simple/obvious code or copy change
 that can be made in a Pull Request to save time,
-simply use the 
+simply use the code suggestion button in the PR comment.
 
+Hover over the line of code where you'd like to add a comment,
+and click the blue comment icon:
 
-See: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/reviewing-proposed-changes-in-a-pull-request
+![add-comment](https://github.com/user-attachments/assets/c23e9c86-e678-4b10-a7f4-c38cb391e365)
+
+to suggest a specific change to the line or lines, click `±`,
+then edit the text within the suggestion block.
+
+![make-code-suggestion](https://github.com/user-attachments/assets/49ee6ecf-aa63-4aca-a2d1-b03e10053fda)
+
+See:
+[docs.github.com/en/pull-requests/collaborating-with-pull-requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/reviewing-proposed-changes-in-a-pull-request)
 
 ### Naming Repos 🌹
 
-+ We favour one-word names for **node modules**
-  (make sure the name is available)
-  and _descriptive_ names for everything else
-  (especially tutorials!)
+We favour one-word names for repos and **node modules**
+(make sure the name is available).
+e.g:
++ [`fields`](https://github.com/dwyl/fields)
++ [`gcal`](https://github.com/dwyl/gcal)
++ [`link`](https://github.com/dwyl/link)
++ [`useful`](https://github.com/dwyl/useful)
++ [`quotes`](https://github.com/dwyl/quotes)
+
+When the name we want is "taken" on the package system we are using,
+we add more words to the repo/package name separated by **hyphens**.
+e.g:
++ [`aws-sdk-mock`](https://github.com/dwyl/aws-sdk-mock)
++ [`elixir-auth-github`](https://github.com/dwyl/elixir-auth-github)
+
+> **Note**: we occasionally use underscores in repo names where 
+
+Try to use _descriptive_ names for everything else
+(especially tutorials!)
+e.g:
++ [`javascript-todo-list-tutorial`](https://github.com/dwyl/javascript-todo-list-tutorial)
++ [`phoenix-liveview-counter-tutorial`](https://github.com/dwyl/phoenix-liveview-counter-tutorial)
++ 
+
+### Naming Files 🗄️
+
+Always use `lowercase` names for files and directories.
+The exception to this are the files `GitHub` creates by default
+e.g:
+`LICENSE`, `README.md`, `CONTRIBUTING` and `CODE_OF_CONDUCT`, etc.
 
 ## Markdown ⬇️
 
@@ -320,6 +358,8 @@ const example_object = {
 [webdesignledger.com/29-online-style-guides](https://webdesignledger.com/29-online-style-guides/)
 + Useful tips for better commit messages:
 [thoughtbot.com/5-useful-tips-for-a-better-commit-message](https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message)
++ CSS for Software Engineers:
+[speakerdeck.com/csswizardry/css-for-software-engineers](https://speakerdeck.com/csswizardry/css-for-software-engineers-for-css-developers)
 
 ## Star it ⭐
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 <div align="center">
 
-![dwyl-style-guide-intro-hero-image-yellow-text](https://github.com/user-attachments/assets/1e20cfa5-94b9-4a28-8e01-8b460b4a653a)
+![dwyl-style-guide-intro-hero-image-yellow-text](https://github.com/user-attachments/assets/1e20cfa5-94b9-4a28-8e01-8b460b4a653a "dwyl style guide retro game start screen")
 
 A style guide sets standards and improves communication.
 ~ [wikipedia.org/Style_guide](https://en.wikipedia.org/wiki/Style_guide)
 
 This style guide is a
 [**work-in-progress**](https://en.wikipedia.org/wiki/Work_in_process)
-we **need _your_ help** to _maintain_ and extend it. 🙏
+we **need _your_ help** to _maintain_ and extend it. 🙏 <br />
+If you spot something that can be improved
+or just have a question, please
+[open an issue](https://github.com/dwyl/style-guide/issues). 💬
 
 [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat-square)](https://github.com/dwyl/style-guide/issues)
 [![HitCount](https://hits.dwyl.com/dwyl/style-guide.svg?style=flat-square)](https://hits.dwyl.com/dwyl/style-guide)
@@ -16,7 +19,7 @@ we **need _your_ help** to _maintain_ and extend it. 🙏
 
 - [Why? 🤷🏻‍♀️](#why-️)
 - [General 👋](#general-)
-  - [Indentation 🪐](#indentation-)
+  - [Indentation ✌️](#indentation-️)
   - [_Intelligently_ Comment Code 💬](#intelligently-comment-code-)
   - [Quotes 🧵](#quotes-)
 - [Git 👩‍💻](#git-)
@@ -24,30 +27,43 @@ we **need _your_ help** to _maintain_ and extend it. 🙏
   - [Commits ✨](#commits-)
   - [Pull Requests 🚀](#pull-requests-)
     - [_Reviewing_ PRs 👀](#reviewing-prs-)
+    - [Use In-line Code Suggestions in PRs! 💡](#use-in-line-code-suggestions-in-prs-)
   - [Naming Repos 🌹](#naming-repos-)
 - [Markdown ⬇️](#markdown-️)
+  - [Semantic Line Breaks](#semantic-line-breaks)
 - [CSS 🌈](#css-)
-  - [Indentation ✌️](#indentation-️)
+  - [Formatting 🦄](#formatting-)
   - [Naming Conventions 🍓](#naming-conventions-)
 - [Grouping Properties 👥](#grouping-properties-)
   - [JavaScript ☕](#javascript-)
   - [Variable Naming 🐍](#variable-naming-)
 - [Recommended Reading 📖](#recommended-reading-)
+- [Star it ⭐](#star-it-)
   
 ## Why? 🤷🏻‍♀️
 
 **_Consistency_**. 😍
 
 Creative people often like to do things their own way.
-That can often lead to projects that look wildly different from each other.
+That's great if you are working _alone_
+but not so good on an established team.
+Many different styles leads to projects
+that look wildly different from each other.
 This slows down new people and wastes time.
 We need **_everything_ consistent** so new people
-_don't have to work through personal formatting quirks_
-of previous engineers and can **focus on the code**. 🎯
+don't have to work through _personal formatting quirks_
+of previous engineers and can **focus on the feature**. 🎯
 
 ## General 👋
 
-### Indentation 🪐
+We follow a handful of general principals
+to keep our projects running smoothly,
+easy to
+[onboard](https://en.wikipedia.org/wiki/Onboarding)
+and
+_maintain_.
+
+### Indentation ✌️
 
 We use
 **2 spaces for indentation**
@@ -64,13 +80,21 @@ we can _only_ use spaces.
 
 ### _Intelligently_ Comment Code 💬
 
-We favour the _intelligent approach_.
+We favour the _intelligent approach_ to commenting code.
 
 Many developers (not us) believe that
 [well-written code doesn't need comments](http://sublimecoding.com/blog/2015/01/12/dont-comment-your-code-rewrite-it).
-Whilst it's true that
-**adding too many comments to your code makes it _unreadable_**.
-The key is: **put yourself in the shoes of the _next_ person who has to work with the code**.
+Whilst it's true in a tiny hello world app where there almost no code,
+it's not the case in a codebase with many thousands of lines
+that has to be 
+[groked](https://en.wikipedia.org/wiki/Grok)
+by several distinct people.
+Yes, in some cases
+**adding too many comments** can also make it **_unreadable_**.
+The key is:
+**put yourself in the shoes** of the
+[**_next_ person**](https://www.goodreads.com/quotes/248194-always-code)
+**who has to work with the code**.
 
 If you feel **your code is as simple as it can be**
 but what it does isn't immediately obvious, then **add a comment**.
@@ -105,22 +129,48 @@ When constructing a string including properties
 which are themselves denoted by single quotes:
 e.g: `var str = "<a class='big' href='/mylink'>click me</a>"`;
 
+Most programming languages we use,
+e.g:
+[`HTML`](https://stackoverflow.com/a/2373171/1148249),
+[`JavaScript`](https://stackoverflow.com/questions/242813),
+[`Dart`](https://stackoverflow.com/a/54014914/1148249)
+allow single and double quotes to be used _interchangeably_.
+But `Elixir` and `JSON` do not.
+`String` in `Elixir` _must_ use double-quotes,
+and _valid_ `JSON` keys/values _must_ be surrounded by double-quotes.
+This is why we use double-quotes for `Strings`;
+it makes everyone's life easier/faster when switching between code bases.
+
+Again, this isn't a debate. 😊
+
 ## Git 👩‍💻
+
+If you are new to `Git` and/or `GitHub`
+we recommend reading our **`Git` Guide**:
 
 ### Issues 📝
 
-+ Your issue/pull request `title` should be **short but descriptive**
-+ Use **`labels`** please! see:
+**`GitHub` Issues** are how we do the vast majority
+of our
+[asynchronous communication](https://en.wikipedia.org/wiki/Asynchronous_communication).
+We follow a simple set of rules that streamline everything:
+
+1. Your issue/pull request `title` should be **short but descriptive**
+2. Use **`labels`** please! see:
 [dwyl/labels](https://github.com/dwyl/labels?tab=readme-ov-file#our-list-of-labels--%EF%B8%8F)
-+ If you want someone specific to look at your issue, **assign it to them**
-+ **When referring to a file**, always do so
+3. To request the input of a specific person on an Issue or PR,
+   mention them in a comment
+   and if you want to _delegate_ a task **assign it to them**.
+   However, don't just assign issues/PRs without any explanation,
+   that's called [Buck passing](https://en.wikipedia.org/wiki/Buck_passing)
+4. **When referring to a file**, always do so
   within the **context of a _specific_ commit**
   (as that file could be constantly changing and your issue will quickly stop making sense)
   + Example: [https://github.com/dwyl/style-guide/blob/<b>dea0009638b7923521a13190f17090af37a7ff22</b>/README.md](https://github.com/dwyl/style-guide/blob/dea0009638b7923521a13190f17090af37a7ff22/README.md)
   + and **_not_** https://github.com/dwyl/style-guide/blob/master/README.md
-  + To get this URL, go to the _History_ tab on the top right of your document and choose a commit form the list that appears    
+  + To get this URL, go to the _History_ tab on the top right of your document and choose a commit form the list that appears
   <img width="288" alt="history-tab-on-git-documents" src="https://cloud.githubusercontent.com/assets/4185328/9290455/55d5dc6e-438c-11e5-851d-71127213f565.png">
-+ **When referring to a specific piece of code, include the line number** that code is on
+1. **When referring to a specific piece of code, include the line number** that code is on
   + You can either add this by add `#L` and the line number to the end of the URL (e.g. https://github.com/dwyl/hapi-socketio-redis-chat-example/blame/b26354e3f37b2bdd0414b9b01bfe45db7ee9504e/lib/chat.js#L6) **or**
   + Go to a specific commit (as above), click on 'View' and then click on 'Blame' in the top right hand corner    
   <img width="274" alt="blame-tab-on-git-documents" src="https://cloud.githubusercontent.com/assets/4185328/9290470/e46c2578-438c-11e5-95a7-19dfbcf82b00.png">
@@ -128,19 +178,19 @@ e.g: `var str = "<a class='big' href='/mylink'>click me</a>"`;
 
 ### Commits ✨
 
-+ Use the **third person present tense** in your commit messages,
+1. Use the **third person present tense** in your commit messages,
   as if you were finishing off the sentence _"This commit message..."_
   e.g: _"adds atm.js to index.html #420"_ or _"fixes disappearing content bug #12"_
-+ **Include an issue number in _every_ commit message**
+2. **Include an issue number in _every_ commit message**
   + The commit message will then appear within that issue and ensure traceability of every contribution.
   
 <img width="704" alt="commit-message-referenced-from-issue" src="https://cloud.githubusercontent.com/assets/4185328/9212670/dda6840c-4082-11e5-8e58-c4077f5ab089.png">
 
-+ Keep your commits **'common sensibly small'**
+1. Keep your commits **'common sensibly small'**
   + A good rule of thumb is that _if you have to use the word "and"
   in your commit message, you're probably doing too much in a single commit_
   unless the things you're committing are intrinsically tied together.
-+ **If you're pairing**, consider giving your pair some credit
+1. **If you're pairing**, consider giving your pair some credit
   in your commit messages by including their initials:
 
 <img width="723" alt="paired-commit-message" src="https://cloud.githubusercontent.com/assets/4185328/9212496/3adc19c2-4081-11e5-956c-8655c1f37946.png">
@@ -170,6 +220,15 @@ please see:
 <img width="940" alt="add-comment-inline-in-pr-comment-box"
   src="https://cloud.githubusercontent.com/assets/4185328/9238544/0d293b20-414b-11e5-8604-15ba4f229525.png">
 
+#### Use In-line Code Suggestions in PRs! 💡
+
+When there is a simple/obvious code or copy change
+that can be made in a Pull Request to save time,
+simply use the 
+
+
+See: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/reviewing-proposed-changes-in-a-pull-request
+
 ### Naming Repos 🌹
 
 + We favour one-word names for **node modules**
@@ -190,12 +249,14 @@ For readability, we use:
   (so they're not confused with bold or italics on first glance)
 + **Section Headings** should always be **followed by** a **blank line**.
 
+### Semantic Line Breaks
+
 
 ## CSS 🌈
 
 + Learn and _Use_ `Tailwind CSS`
   [dwyl/learn-tailwind](https://github.com/dwyl/learn-tailwind)
-  great _interface_ is the key to a great _experience_.
+  **great _interface_** is essential to a **great _experience_**.
 + If you use a _separate_ CSS file,
   use _classes_, **not IDs** as your hooks
 + Explicitly select **what you want** rather than fumbling around
@@ -206,9 +267,9 @@ For readability, we use:
 + Pick class names that are as re-usable as possible
   (e.g. pick `primary-nav` over `site-nav`)
 
-### Indentation ✌️
+### Formatting 🦄
 
-CSS indentation should mirror the `HTML` markup structure,
+CSS formatting and indentation should mirror the `HTML` markup structure,
 e.g: 
 
 ```css
@@ -247,9 +308,10 @@ const example_object = {
 ### Variable Naming 🐍
 
 + If you can, use a descriptive **one word** variable name
-+ If one word isn't enough, **use underscores to separate words**
-  ([`snake_case`](https://en.wikipedia.org/wiki/Snake_case))
-  and not [`camelCase`](https://en.wikipedia.org/wiki/CamelCase),
++ If one word isn't enough, **use underscores to separate words**;
+  [`snake_case`](https://en.wikipedia.org/wiki/Snake_case))
+  _not_ 
+  [`camelCase`](https://en.wikipedia.org/wiki/CamelCase) <br />
   e.g: `let auth_token = "e2jxyz.etc.etc`
 
 ## Recommended Reading 📖
@@ -258,3 +320,11 @@ const example_object = {
 [webdesignledger.com/29-online-style-guides](https://webdesignledger.com/29-online-style-guides/)
 + Useful tips for better commit messages:
 [thoughtbot.com/5-useful-tips-for-a-better-commit-message](https://robots.thoughtbot.com/5-useful-tips-for-a-better-commit-message)
+
+## Star it ⭐
+
+The best way to let everyone know you have read
+and _understood_ this style guide is to
+star the repo on `GitHub`. 🌟
+
+Thank you! ❤️


### PR DESCRIPTION
Noticed that the Style Guide was a bit ... neglected. 😞 
So while adding the section on semantic line breaks, did a bit of tidying and enhancement. 🪄 

# In this PR: 

Several older issues were closed:

+ [x] Reformat *existing* README.md to conform to our own style guide 
+ [x] Add semantic line breaks instruction to `Markdown` section 📝 #9
+ [x] Add `.editorconfig` file for consistency between editors and contributors #11 
+ [x] Visual Style Guide link #12
+ [x] Update CSS Framework to `Tailwind` #19 
+ [x]  Documentation guidelines #20 
+ [x] ***lowercase*** filenames #26 
+ [x] Add section on _descriptive_ Semantic Link Text #32

***Before***:
https://github.com/dwyl/style-guide/blob/24820a420d66b5e0d57d652cd2f10391058e80c5/README.md

![image](https://github.com/user-attachments/assets/ff273ec0-8c49-4b72-b31d-b01712a6ba01)

***After***:

![image](https://github.com/user-attachments/assets/09bcd58f-3756-4865-a707-741bdb2ff0ff)